### PR TITLE
Handle empty monos on served queries handlers

### DIFF
--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/EmptyMessage.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/EmptyMessage.java
@@ -1,0 +1,40 @@
+package org.reactivecommons.async.impl;
+
+import org.reactivecommons.async.impl.communications.Message;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.Map;
+
+public class EmptyMessage implements Message {
+
+    @Override
+    public byte[] getBody() {
+        return new byte[0];
+    }
+
+    @Override
+    public Properties getProperties() {
+        return new Properties() {
+            @Override
+            public String getContentType() {
+                return "application/octet-stream";
+            }
+
+            @Override
+            public String getContentEncoding() {
+                return Charset.defaultCharset().name();
+            }
+
+            @Override
+            public long getContentLength() {
+                return 0;
+            }
+
+            @Override
+            public Map<String, Object> getHeaders() {
+                return Collections.emptyMap();
+            }
+        };
+    }
+}

--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/listeners/GenericMessageListener.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/listeners/GenericMessageListener.java
@@ -1,15 +1,14 @@
 package org.reactivecommons.async.impl.listeners;
 
 import lombok.extern.java.Log;
-import org.reactivecommons.async.impl.communications.Message;
 import org.reactivecommons.async.impl.RabbitMessage;
+import org.reactivecommons.async.impl.communications.Message;
 import org.reactivecommons.async.impl.communications.ReactiveMessageListener;
 import org.reactivecommons.async.impl.communications.TopologyCreator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
 import reactor.rabbitmq.Receiver;
-import reactor.util.function.Tuple2;
 
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,10 +36,10 @@ public abstract class GenericMessageListener {
 
     public void startListener() {
         setUpBindings(messageListener.getTopologyCreator()).thenMany(
-        receiver.consumeManualAck(queueName)
-            .transform(this::consumeFaultTolerant)
-            .transform(this::outerFailureProtection))
-            .subscribe();
+                receiver.consumeManualAck(queueName)
+                        .transform(this::consumeFaultTolerant)
+                        .transform(this::outerFailureProtection))
+                .subscribe();
     }
 
 
@@ -48,18 +47,20 @@ public abstract class GenericMessageListener {
     private Mono<AcknowledgableDelivery> handle(AcknowledgableDelivery msj) {
         final Function<Message, Mono<Object>> handler = getExecutor(getExecutorPath(msj));
         final Message message = RabbitMessage.fromDelivery(msj);
-        return Mono.defer(() -> handler.apply(message).zipWith(Mono.just(msj)).transform(this::enrichPostProcess)).thenReturn(msj);
+        return Mono.defer(() -> handler.apply(message)
+                .transform(data -> enrichPostProcess(data, msj)))
+                .thenReturn(msj);
     }
 
 
     private <T> Flux<T> outerFailureProtection(Flux<T> messageFlux) {
         return messageFlux.onErrorContinue(t -> true, (throwable, elem) -> {
-            if(elem instanceof AcknowledgableDelivery){
+            if (elem instanceof AcknowledgableDelivery) {
                 try {
                     Mono.delay(Duration.ofMillis(350)).doOnSuccess(_n -> ((AcknowledgableDelivery) elem).nack(true)).subscribe();
                     log.log(Level.SEVERE, "Outer error protection reached for Async Consumer!! Severe Warning! ", throwable);
                     log.warning("Returning message to communications: " + ((AcknowledgableDelivery) elem).getProperties().getHeaders().toString());
-                }catch (Exception e){
+                } catch (Exception e) {
                     log.log(Level.SEVERE, "Error returning message in failure!", e);
                 }
             }
@@ -68,17 +69,17 @@ public abstract class GenericMessageListener {
 
     private Flux<AcknowledgableDelivery> consumeFaultTolerant(Flux<AcknowledgableDelivery> messageFlux) {
         return messageFlux.flatMap(msj ->
-            handle(msj)
-                .onErrorResume(err -> {
-                    try {
-                        log.log(Level.SEVERE, "Error encounter while processing message:", err);
-                        log.warning("Returning message to communications in 200ms: " + msj.getProperties().getHeaders().toString());
-                        log.warning(new String(msj.getBody()));
-                    } catch (Exception e) {
-                        log.log(Level.SEVERE, "Log Error", e);
-                    }
-                    return Mono.just(msj).delayElement(Duration.ofMillis(200)).doOnNext(s -> msj.nack(true));
-                }).doOnSuccess(s -> msj.ack())
+                handle(msj)
+                        .onErrorResume(err -> {
+                            try {
+                                log.log(Level.SEVERE, "Error encounter while processing message:", err);
+                                log.warning("Returning message to communications in 200ms: " + msj.getProperties().getHeaders().toString());
+                                log.warning(new String(msj.getBody()));
+                            } catch (Exception e) {
+                                log.log(Level.SEVERE, "Log Error", e);
+                            }
+                            return Mono.just(msj).delayElement(Duration.ofMillis(200)).doOnNext(s -> msj.nack(true));
+                        }).doOnSuccess(s -> msj.ack())
         );
     }
 
@@ -89,16 +90,17 @@ public abstract class GenericMessageListener {
 
     private Function<Message, Mono<Object>> computeRawMessageHandler(String commandId) {
         return handlers.computeIfAbsent(commandId, s ->
-            rawMessageHandler(commandId)
+                rawMessageHandler(commandId)
         );
     }
 
     protected abstract Function<Message, Mono<Object>> rawMessageHandler(String executorPath);
-    protected abstract String getExecutorPath(AcknowledgableDelivery msj);
-    protected Mono<Object> enrichPostProcess(Mono<Tuple2<Object, AcknowledgableDelivery>> flow){
-        return flow.map(Tuple2::getT1);
-    }
 
+    protected abstract String getExecutorPath(AcknowledgableDelivery msj);
+
+    protected Mono<Void> enrichPostProcess(Mono<Object> data, AcknowledgableDelivery delivery) {
+        return Mono.empty();
+    }
 
 
 }

--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/reply/ReactiveReplyRouter.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/reply/ReactiveReplyRouter.java
@@ -29,4 +29,11 @@ public class ReactiveReplyRouter {
             processor.onError(new RuntimeException(data));
         }
     }
+
+    public void routeEmpty(String correlationID) {
+        final UnicastProcessor<String> processor = processors.remove(correlationID);
+        if (processor != null) {
+            processor.onComplete();
+        }
+    }
 }

--- a/domain/domain-events/src/main/java/org/reactivecommons/api/domain/Headers.java
+++ b/domain/domain-events/src/main/java/org/reactivecommons/api/domain/Headers.java
@@ -1,0 +1,15 @@
+package org.reactivecommons.api.domain;
+
+public final class Headers {
+
+    public static final String REPLY_ID = "x-reply_id";
+    public static final String CORRELATION_ID = "x-correlation-id";
+    public static final String SERVED_QUERY_ID = "x-serveQuery-id";
+    public static final String SOURCE_APPLICATION = "sourceApplication";
+    public static final String SIGNAL_TYPE = "x-signal-type";
+
+
+    private Headers() {
+    }
+
+}

--- a/samples/async/receiver-responder/src/main/java/sample/EmptyReceiver.java
+++ b/samples/async/receiver-responder/src/main/java/sample/EmptyReceiver.java
@@ -1,0 +1,13 @@
+package sample;
+
+import org.reactivecommons.async.api.handlers.QueryHandler;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class EmptyReceiver implements QueryHandler<String, String> {
+    @Override
+    public Mono<String> handle(String message) {
+        return Mono.empty();
+    }
+}

--- a/samples/async/receiver-responder/src/main/java/sample/SampleReceiverApp.java
+++ b/samples/async/receiver-responder/src/main/java/sample/SampleReceiverApp.java
@@ -3,8 +3,8 @@ package sample;
 import lombok.RequiredArgsConstructor;
 import org.reactivecommons.api.domain.DomainEvent;
 import org.reactivecommons.api.domain.DomainEventBus;
-import org.reactivecommons.async.api.handlers.QueryHandler;
 import org.reactivecommons.async.api.HandlerRegistry;
+import org.reactivecommons.async.api.handlers.QueryHandler;
 import org.reactivecommons.async.impl.config.annotations.EnableDomainEventBus;
 import org.reactivecommons.async.impl.config.annotations.EnableMessageListeners;
 import org.springframework.boot.SpringApplication;
@@ -21,21 +21,22 @@ public class SampleReceiverApp {
     }
 
     @Bean
-    public HandlerRegistry handlerRegistry(MemberReceiver receiver) {
+    public HandlerRegistry handlerRegistry(MemberReceiver receiver, EmptyReceiver emptyReceiver) {
         return HandlerRegistry.register()
-            .serveQuery("serveQuery.register.member", receiver)
-            .serveQuery("serveQuery.register.member.new", new QueryHandler<MemberRegisteredEvent, AddMemberCommand>(){
-                @Override
-                public Mono<MemberRegisteredEvent> handle(AddMemberCommand command) {
-                    return Mono.just(new MemberRegisteredEvent("42", 69));
-                }
-            });
+                .serveQuery("serveQuery.register.member", receiver)
+                .serveQuery("serveQuery.register.member.new", new QueryHandler<MemberRegisteredEvent, AddMemberCommand>() {
+                    @Override
+                    public Mono<MemberRegisteredEvent> handle(AddMemberCommand command) {
+                        return Mono.just(new MemberRegisteredEvent("42", 69));
+                    }
+                })
+                .serveQuery("serveQuery.empty", emptyReceiver);
     }
 
     @Bean
     public HandlerRegistry eventListeners(SampleUseCase useCase) {
         return HandlerRegistry.register()
-            .listenEvent("persona.registrada", useCase::reactToPersonaEvent, MemberRegisteredEvent.class);
+                .listenEvent("persona.registrada", useCase::reactToPersonaEvent, MemberRegisteredEvent.class);
     }
 
 
@@ -48,9 +49,9 @@ public class SampleReceiverApp {
     public static class SampleUseCase {
         private final DomainEventBus eventBus;
 
-        public Mono<Void> reactToPersonaEvent(DomainEvent<MemberRegisteredEvent> event){
+        public Mono<Void> reactToPersonaEvent(DomainEvent<MemberRegisteredEvent> event) {
             return Mono.from(eventBus.emit(new DomainEvent<>("persona.procesada", "213", event.getData())))
-                .doOnSuccess(_v -> System.out.println("Persona procesada"));
+                    .doOnSuccess(_v -> System.out.println("Persona procesada"));
         }
     }
 

--- a/samples/async/sender-client/src/main/java/sample/SampleSenderApp.java
+++ b/samples/async/sender-client/src/main/java/sample/SampleSenderApp.java
@@ -1,6 +1,8 @@
 package sample;
 
 import lombok.extern.java.Log;
+import org.reactivecommons.async.api.AsyncQuery;
+import org.reactivecommons.async.api.DirectAsyncGateway;
 import org.reactivecommons.async.impl.config.annotations.EnableDirectAsyncGateway;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -22,18 +24,22 @@ public class SampleSenderApp {
     }
 
     @Bean
-    public CommandLineRunner run(MemberRegistrySender sender) {
+    public CommandLineRunner run(MemberRegistrySender sender, DirectAsyncGateway directAsyncGateway) {
         return args -> {
             Flux.interval(Duration.ofSeconds(1)).concatMap(n -> {
-                AddMemberCommand command = new AddMemberCommand("Daniel " + n, n+"");
+                AddMemberCommand command = new AddMemberCommand("Daniel " + n, n + "");
                 return Mono.defer(() -> sender.registerMember(command));
-            })  .doOnError(t -> log.warning(t.getMessage()))
-                .retry()
-                .subscribe(event -> {
-                    log.info("Registered Event");
-                    log.info(event.getMemberId());
-                    log.info(event.getInitialScore() + " Score");
-                });
+            }).doOnError(t -> log.warning(t.getMessage()))
+                    .retry()
+                    .subscribe(event -> {
+                        log.info("Registered Event");
+                        log.info(event.getMemberId());
+                        log.info(event.getInitialScore() + " Score");
+                    });
+
+            directAsyncGateway.requestReply(new AsyncQuery<>("serveQuery.empty", "test"), "Receiver2", String.class)
+                    .defaultIfEmpty("empty!")
+                    .subscribe(result -> System.out.println("Arrived " + result));
         };
     }
 }

--- a/samples/async/simpleConsumer/src/main/java/sample/App.java
+++ b/samples/async/simpleConsumer/src/main/java/sample/App.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.UnicastProcessor;
 import reactor.core.scheduler.Schedulers;
 import reactor.rabbitmq.*;
 import reactor.util.context.Context;
@@ -24,7 +25,6 @@ public class App {
     @Bean
     public CommandLineRunner runner() {
         return args -> {
-
 //            ConnectionFactory factory = new ConnectionFactory();
 //            factory.setTopologyRecoveryEnabled(true);
 //            factory.setAutomaticRecoveryEnabled(true);


### PR DESCRIPTION
Using a header called signal-type the query handler identifies if the result is an empty mono and diffuse that, It could be used too for error emissions.
fixes #1 