### PR TITLE
fix(jackson): Spring compatible starter is not using the ObjectMapper instance configured by Spring

### DIFF
--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/DefaultObjectMapperSupplier.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/DefaultObjectMapperSupplier.java
@@ -1,0 +1,16 @@
+package org.reactivecommons.async.impl.converters.json;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DefaultObjectMapperSupplier implements ObjectMapperSupplier {
+
+    @Override
+    public ObjectMapper get() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return objectMapper;
+    }
+
+}

--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/JacksonMessageConverter.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/JacksonMessageConverter.java
@@ -1,16 +1,15 @@
-package org.reactivecommons.async.impl.converters;
+package org.reactivecommons.async.impl.converters.json;
 
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 import org.reactivecommons.api.domain.Command;
 import org.reactivecommons.api.domain.DomainEvent;
 import org.reactivecommons.async.api.AsyncQuery;
-import org.reactivecommons.async.impl.communications.Message;
-import org.reactivecommons.async.impl.exceptions.MessageConversionException;
 import org.reactivecommons.async.impl.RabbitMessage;
+import org.reactivecommons.async.impl.communications.Message;
+import org.reactivecommons.async.impl.converters.MessageConverter;
+import org.reactivecommons.async.impl.exceptions.MessageConversionException;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -21,9 +20,8 @@ public class JacksonMessageConverter implements MessageConverter {
 
     private final ObjectMapper objectMapper;
 
-    public JacksonMessageConverter() {
-        final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    public JacksonMessageConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 

--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/ObjectMapperSupplier.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/converters/json/ObjectMapperSupplier.java
@@ -1,0 +1,8 @@
+package org.reactivecommons.async.impl.converters.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.function.Supplier;
+
+public interface ObjectMapperSupplier extends Supplier<ObjectMapper> {
+}

--- a/async/async-commons/src/main/java/org/reactivecommons/async/impl/listeners/ApplicationCommandListener.java
+++ b/async/async-commons/src/main/java/org/reactivecommons/async/impl/listeners/ApplicationCommandListener.java
@@ -11,7 +11,6 @@ import org.reactivecommons.async.impl.HandlerResolver;
 import org.reactivecommons.async.impl.RabbitMessage;
 import org.reactivecommons.async.impl.communications.ReactiveMessageListener;
 import org.reactivecommons.async.impl.communications.TopologyCreator;
-import org.reactivecommons.async.impl.converters.JacksonMessageConverter;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.AcknowledgableDelivery;
 import reactor.rabbitmq.BindingSpecification;

--- a/async/async-commons/src/test/java/org/reactivecommons/async/impl/communications/ReactiveMessageSenderTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/impl/communications/ReactiveMessageSenderTest.java
@@ -9,8 +9,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.reactivecommons.async.impl.converters.JacksonMessageConverter;
 import org.reactivecommons.async.impl.converters.MessageConverter;
+import org.reactivecommons.async.impl.converters.json.JacksonMessageConverter;
+import org.springframework.boot.test.context.SpringBootTest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.rabbitmq.OutboundMessageResult;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
+@SpringBootTest
 @RunWith(MockitoJUnitRunner.class)
 public class ReactiveMessageSenderTest {
 
@@ -32,11 +34,13 @@ public class ReactiveMessageSenderTest {
 
     private OutboundMessageResult result = new OutboundMessageResult(null, true);
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Mock
     private Sender sender;
 
     @Spy
-    private final MessageConverter messageConverter = new JacksonMessageConverter();
+    private final MessageConverter messageConverter = new JacksonMessageConverter(objectMapper);
 
     @Before
     public void init() {

--- a/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/DefaultObjectMapperSupplierTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/DefaultObjectMapperSupplierTest.java
@@ -1,0 +1,40 @@
+package org.reactivecommons.async.impl.converters.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultObjectMapperSupplierTest {
+
+    private final DefaultObjectMapperSupplier defaultObjectMapperSupplier = new DefaultObjectMapperSupplier();
+
+
+    @Test
+    public void shouldMapWithUnknownProperties() throws IOException {
+        ObjectMapper objectMapper = defaultObjectMapperSupplier.get();
+
+        SampleClassExtra base = new SampleClassExtra("23", "one", new Date(), 45l);
+        final String serialized = objectMapper.writeValueAsString(base);
+
+        final SampleClass result = objectMapper.readValue(serialized, SampleClass.class);
+
+        assertThat(result).isEqualToComparingFieldByField(base);
+    }
+
+    @Getter
+    private static class SampleClassExtra extends SampleClass {
+
+        public SampleClassExtra(String id, String name, Date date, Long newProp) {
+            super(id, name, date);
+            this.newProp = newProp;
+        }
+
+        private final Long newProp;
+    }
+
+}

--- a/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/JacksonMessageConverterTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/JacksonMessageConverterTest.java
@@ -1,13 +1,8 @@
-package org.reactivecommons.async.impl.converters;
+package org.reactivecommons.async.impl.converters.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.junit.Test;
-import org.reactivecommons.api.domain.Command;
-import org.reactivecommons.async.impl.RabbitMessage;
 import org.reactivecommons.async.impl.communications.Message;
 
 import java.io.IOException;
@@ -18,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JacksonMessageConverterTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final JacksonMessageConverter converter = new JacksonMessageConverter();
+    private final JacksonMessageConverter converter = new JacksonMessageConverter(objectMapper);
 
     @Test
     public void toMessage() {
@@ -43,25 +38,12 @@ public class JacksonMessageConverterTest {
     }
 
     @Test
-    public void shouldConvertWithUnknownProperties() throws JsonProcessingException {
-
-        final String value = objectMapper.writeValueAsString(new Command<>("test", "42",
-            new SampleClassExtra("23", "one", new Date(), 45l)));
-
-        final Command<SampleClass> command = converter.readCommand(new RabbitMessage(value.getBytes(),
-            null), SampleClass.class);
-
-        assertThat(command.getData()).extracting(SampleClass::getId, SampleClass::getName)
-            .containsExactly("23", "one");
-    }
-
-    @Test
     public void readValue() {
         Date date = new Date();
         final Message message = converter.toMessage(new SampleClass("35", "name1", date));
         final SampleClass value = converter.readValue(message, SampleClass.class);
         assertThat(value).extracting(SampleClass::getId, SampleClass::getName, SampleClass::getDate)
-            .containsExactly("35", "name1", date);
+                .containsExactly("35", "name1", date);
     }
 
     @Test
@@ -71,22 +53,4 @@ public class JacksonMessageConverterTest {
         assertThat(value).isEqualTo("Hi!");
     }
 
-    @RequiredArgsConstructor
-    @Getter
-    private static class SampleClass {
-        private final String id;
-        private final String name;
-        private final Date date;
-    }
-
-    @Getter
-    private static class SampleClassExtra extends SampleClass {
-
-        public SampleClassExtra(String id, String name, Date date, Long newProp) {
-            super(id, name, date);
-            this.newProp = newProp;
-        }
-
-        private final Long newProp;
-    }
 }

--- a/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/SampleClass.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/impl/converters/json/SampleClass.java
@@ -1,0 +1,14 @@
+package org.reactivecommons.async.impl.converters.json;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Getter
+class SampleClass {
+    private final String id;
+    private final String name;
+    private final Date date;
+}


### PR DESCRIPTION
The instance of ObjectMapper is now received as a dependecy of the class by the constructor

`ObjectMapperSupplier` allows custom ObjectMapper instance providing

fix #25