### PR TITLE
fix: avoid publish blocking with channels pooling

### DIFF
--- a/async/async-commons-standalone/src/main/java/org/reactivecommons/async/impl/config/RabbitProperties.java
+++ b/async/async-commons-standalone/src/main/java/org/reactivecommons/async/impl/config/RabbitProperties.java
@@ -9,4 +9,5 @@ public class RabbitProperties {
     private String username = "guest";
     private String password = "guest";
     private String virtualHost;
+    private Integer channelPoolMaxCacheSize;
 }

--- a/async/async-commons/async-commons.gradle
+++ b/async/async-commons/async-commons.gradle
@@ -76,7 +76,7 @@ dependencies {
     compile project(":domain-events-api")
 
     api 'io.projectreactor:reactor-core'
-    api "io.projectreactor.rabbitmq:reactor-rabbitmq:1.0.0.RELEASE"
+    api "io.projectreactor.rabbitmq:reactor-rabbitmq:1.2.0.RELEASE"
     api 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
     testImplementation 'io.projectreactor:reactor-test'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jul 24 11:42:46 COT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip

--- a/samples/async/simpleConsumer/simple-consumer.gradle
+++ b/samples/async/simpleConsumer/simple-consumer.gradle
@@ -2,5 +2,5 @@ dependencies {
 //    compile 'org.springframework.boot:spring-boot-starter-amqp'
     compile('org.springframework.boot:spring-boot-starter')
 //    compile project(":async:libs:reactor-rabbitmq")
-    compile "io.projectreactor.rabbitmq:reactor-rabbitmq:1.0.0.RC1"
+    compile "io.projectreactor.rabbitmq:reactor-rabbitmq:1.2.0.RELEASE"
 }


### PR DESCRIPTION
Add support for channel pool supported by reactor-rabbitmq on previous releases, the size of the cache can be parametrized with the property 
`spring.rabbitmq.cache.channel.size=`