### PR TITLE
add health indicator

### DIFF
--- a/async/async-rabbit-starter/async-commons-rabbit-starter.gradle
+++ b/async/async-rabbit-starter/async-commons-rabbit-starter.gradle
@@ -6,8 +6,10 @@ ext {
 dependencies {
     api project(':async-rabbit')
     compileOnly 'org.springframework.boot:spring-boot-starter'
+    compileOnly 'org.springframework.boot:spring-boot-starter-actuator'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-actuator'
 }

--- a/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/RabbitHealthConfig.java
+++ b/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/RabbitHealthConfig.java
@@ -1,0 +1,17 @@
+package org.reactivecommons.async.rabbit.config;
+
+import org.reactivecommons.async.rabbit.health.RabbitReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnClass(AbstractReactiveHealthIndicator.class)
+public class RabbitHealthConfig {
+
+    @Bean
+    public RabbitReactiveHealthIndicator rabbitHealthIndicator(ConnectionFactoryProvider provider) {
+        return new RabbitReactiveHealthIndicator(provider);
+    }
+}

--- a/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/RabbitMqConfig.java
+++ b/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/RabbitMqConfig.java
@@ -58,7 +58,7 @@ import static reactor.rabbitmq.ExchangeSpecification.exchange;
         RabbitProperties.class,
         AsyncProps.class
 })
-@Import(BrokerConfigProps.class)
+@Import({BrokerConfigProps.class, RabbitHealthConfig.class})
 public class RabbitMqConfig {
 
     private static final String LISTENER_TYPE = "listener";

--- a/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/health/RabbitReactiveHealthIndicator.java
+++ b/async/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/health/RabbitReactiveHealthIndicator.java
@@ -1,0 +1,35 @@
+package org.reactivecommons.async.rabbit.health;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.reactivecommons.async.rabbit.config.ConnectionFactoryProvider;
+import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class RabbitReactiveHealthIndicator extends AbstractReactiveHealthIndicator {
+    private static final String VERSION = "version";
+    private final ConnectionFactoryProvider provider;
+
+    @Override
+    protected Mono<Health> doHealthCheck(Health.Builder builder) {
+        return Mono.defer(this::getVersion)
+                .map(version -> builder.up().withDetail(VERSION, version).build());
+    }
+
+    private Mono<String> getVersion() {
+        return Mono.just(provider)
+                .map(ConnectionFactoryProvider::getConnectionFactory)
+                .map(this::getRawVersion);
+    }
+
+    @SneakyThrows
+    private String getRawVersion(ConnectionFactory factory) {
+        try (Connection connection = factory.newConnection()) {
+            return connection.getServerProperties().get(VERSION).toString();
+        }
+    }
+}

--- a/async/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/health/RabbitReactiveHealthIndicatorTest.java
+++ b/async/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/health/RabbitReactiveHealthIndicatorTest.java
@@ -1,0 +1,71 @@
+package org.reactivecommons.async.rabbit.health;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.async.rabbit.config.ConnectionFactoryProvider;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.actuate.health.Status;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RabbitReactiveHealthIndicatorTest {
+    @Mock
+    private ConnectionFactoryProvider provider;
+    @Mock
+    private ConnectionFactory factory;
+    @Mock
+    private Connection connection;
+    @InjectMocks
+    private RabbitReactiveHealthIndicator indicator;
+
+    @BeforeEach
+    void setup() {
+        when(provider.getConnectionFactory()).thenReturn(factory);
+    }
+
+    @Test
+    void shouldBeUp() throws IOException, TimeoutException {
+        // Arrange
+        Map<String, Object> properties = new TreeMap<>();
+        properties.put("version", "1.2.3");
+        when(factory.newConnection()).thenReturn(connection);
+        when(connection.getServerProperties()).thenReturn(properties);
+        // Act
+        Mono<Health> result = indicator.doHealthCheck(new Builder());
+        // Assert
+        StepVerifier.create(result)
+                .assertNext(health -> {
+                    assertEquals("1.2.3", health.getDetails().get("version"));
+                    assertEquals(Status.UP, health.getStatus());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldBeDown() throws IOException, TimeoutException {
+        // Arrange
+        when(factory.newConnection()).thenThrow(new TimeoutException("Connection timeout"));
+        // Act
+        Mono<Health> result = indicator.doHealthCheck(new Builder());
+        // Assert
+        StepVerifier.create(result)
+                .expectError(TimeoutException.class)
+                .verify();
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.2
+version=1.0.3
 springBootVersion=2.4.2
 gradleVersionsVersion=0.36.0
 toPublish=async-commons,async-commons-api,async-commons-rabbit-standalone,async-commons-rabbit-starter,domain-events-api,async-rabbit

--- a/samples/async/sender-client/async-sender-client.gradle
+++ b/samples/async/sender-client/async-sender-client.gradle
@@ -2,8 +2,8 @@ apply plugin: 'org.springframework.boot'
 
 dependencies {
     compile project(":async-commons-rabbit-starter")
-//    compile 'org.reactivecommons:async-commons-starter:1.0.0-beta7'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-webflux'
     compile('org.springframework.boot:spring-boot-starter')
+    compile('org.springframework.boot:spring-boot-starter-actuator')
     //runtime('org.springframework.boot:spring-boot-devtools')
 }

--- a/samples/async/sender-client/src/main/resources/application.properties
+++ b/samples/async/sender-client/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=sender
 server.port=4001
 spring.rabbitmq.virtual-host=test
+management.endpoint.health.show-details=always


### PR DESCRIPTION
Features:
- Add default rabbit health indicator that will be enabled only when actuator is present. This feature requires that a bean of kind ConnectionFactoryProvider be available.

  The probe output will be like:

  ![image](https://user-images.githubusercontent.com/8420868/135937143-8fb84b67-face-47d1-9c1e-fa49e9f9a9de.png)

  This pull request closes #23 
  
  ![image](https://user-images.githubusercontent.com/8420868/135937748-c8335569-3115-4e68-a851-3ba32c7cd4f6.png)
