### PR TITLE
fix event bindings for dynamic events

### DIFF
--- a/async/async-commons-api/src/main/java/org/reactivecommons/async/api/HandlerRegistry.java
+++ b/async/async-commons-api/src/main/java/org/reactivecommons/async/api/HandlerRegistry.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class HandlerRegistry {
 
     private final List<RegisteredEventListener<?>> eventListeners = new CopyOnWriteArrayList<>();
+    private final List<RegisteredEventListener<?>> dynamicEventHandlers = new CopyOnWriteArrayList<>();
     private final List<RegisteredEventListener<?>> eventNotificationListener = new CopyOnWriteArrayList<>();
     private final List<RegisteredQueryHandler<?, ?>> handlers = new CopyOnWriteArrayList<>();
     private final List<RegisteredCommandHandler<?>> commandHandlers = new CopyOnWriteArrayList<>();
@@ -42,27 +43,11 @@ public class HandlerRegistry {
         return this;
     }
 
-    /**
-     * @param eventNamePattern
-     * @param handler
-     * @param eventClass
-     * @param <T>
-     * @return HandlerRegistry
-     * Avoid use this deprecated method please use listenEvent
-     */
-    @Deprecated
     public <T> HandlerRegistry handleDynamicEvents(String eventNamePattern, EventHandler<T> handler, Class<T> eventClass) {
-        return listenEvent(eventNamePattern, handler, eventClass);
+        dynamicEventHandlers.add(new RegisteredEventListener<>(eventNamePattern, handler, eventClass));
+        return this;
     }
 
-    /**
-     * @param eventNamePattern
-     * @param handler
-     * @param <T>
-     * @return HandlerRegistry
-     * Avoid use this deprecated method please use listenEvent
-     */
-    @Deprecated
     public <T> HandlerRegistry handleDynamicEvents(String eventNamePattern, EventHandler<T> handler) {
         return handleDynamicEvents(eventNamePattern, handler, inferGenericParameterType(handler));
     }

--- a/async/async-rabbit/src/main/java/org/reactivecommons/async/rabbit/HandlerResolver.java
+++ b/async/async-rabbit/src/main/java/org/reactivecommons/async/rabbit/HandlerResolver.java
@@ -18,6 +18,7 @@ public class HandlerResolver {
 
     private final Map<String, RegisteredQueryHandler<?, ?>> queryHandlers;
     private final Map<String, RegisteredEventListener<?>> eventListeners;
+    private final Map<String, RegisteredEventListener<?>> eventsToBind;
     private final Map<String, RegisteredEventListener<?>> eventNotificationListeners;
     private final Map<String, RegisteredCommandHandler<?>> commandHandlers;
     private final Matcher matcher = new KeyMatcher();
@@ -53,8 +54,9 @@ public class HandlerResolver {
                 .computeIfAbsent(path, getMatchHandler(eventNotificationListeners));
     }
 
+    // Returns only the listenEvent not the handleDynamicEvents
     public Collection<RegisteredEventListener<?>> getEventListeners() {
-        return eventListeners.values();
+        return eventsToBind.values();
     }
 
     void addEventListener(RegisteredEventListener<?> listener) {

--- a/async/async-rabbit/src/main/java/org/reactivecommons/async/rabbit/listeners/ApplicationEventListener.java
+++ b/async/async-rabbit/src/main/java/org/reactivecommons/async/rabbit/listeners/ApplicationEventListener.java
@@ -9,8 +9,6 @@ import org.reactivecommons.async.commons.EventExecutor;
 import org.reactivecommons.async.commons.communications.Message;
 import org.reactivecommons.async.commons.converters.MessageConverter;
 import org.reactivecommons.async.commons.ext.CustomReporter;
-import org.reactivecommons.async.commons.utils.matcher.KeyMatcher;
-import org.reactivecommons.async.commons.utils.matcher.Matcher;
 import org.reactivecommons.async.rabbit.HandlerResolver;
 import org.reactivecommons.async.rabbit.communications.ReactiveMessageListener;
 import org.reactivecommons.async.rabbit.communications.TopologyCreator;
@@ -35,7 +33,6 @@ public class ApplicationEventListener extends GenericMessageListener {
     private final boolean withDLQRetry;
     private final int retryDelay;
     private final Optional<Integer> maxLengthBytes;
-    private final Matcher keyMatcher;
     private final String appName;
 
 
@@ -57,7 +54,6 @@ public class ApplicationEventListener extends GenericMessageListener {
         this.eventsExchange = eventsExchange;
         this.messageConverter = messageConverter;
         this.maxLengthBytes = maxLengthBytes;
-        this.keyMatcher = new KeyMatcher();
         this.appName = appName;
     }
 

--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/DynamicRegistryImpTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/DynamicRegistryImpTest.java
@@ -45,9 +45,10 @@ class DynamicRegistryImpTest {
     void setUp() {
         Map<String, RegisteredCommandHandler<?>> commandHandlers = new ConcurrentHashMap<>();
         Map<String, RegisteredEventListener<?>> eventListeners = new ConcurrentHashMap<>();
+        Map<String, RegisteredEventListener<?>> eventsToBind = new ConcurrentHashMap<>();
         Map<String, RegisteredEventListener<?>> notificationEventListeners = new ConcurrentHashMap<>();
         Map<String, RegisteredQueryHandler<?, ?>> queryHandlers = new ConcurrentHashMap<>();
-        resolver = new HandlerResolver(queryHandlers, eventListeners, notificationEventListeners, commandHandlers);
+        resolver = new HandlerResolver(queryHandlers, eventListeners, eventsToBind, notificationEventListeners, commandHandlers);
         dynamicRegistry = new DynamicRegistryImp(resolver, topologyCreator, props);
     }
 

--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/HandlerResolverTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/HandlerResolverTest.java
@@ -1,0 +1,57 @@
+package org.reactivecommons.async.rabbit;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.async.api.handlers.registered.RegisteredCommandHandler;
+import org.reactivecommons.async.api.handlers.registered.RegisteredEventListener;
+import org.reactivecommons.async.api.handlers.registered.RegisteredQueryHandler;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class HandlerResolverTest {
+    private HandlerResolver resolver;
+
+    @BeforeEach
+    void setup() {
+        Map<String, RegisteredCommandHandler<?>> commandHandlers = new ConcurrentHashMap<>();
+        Map<String, RegisteredEventListener<?>> eventListeners = new ConcurrentHashMap<>();
+        eventListeners.put("event.name", new RegisteredEventListener<>("event.name", message -> Mono.empty(), String.class));
+        eventListeners.put("event.name2", new RegisteredEventListener<>("event.name2", message -> Mono.empty(), String.class));
+        eventListeners.put("some.*", new RegisteredEventListener<>("some.*", message -> Mono.empty(), String.class));
+        Map<String, RegisteredEventListener<?>> eventsToBind = new ConcurrentHashMap<>();
+        eventsToBind.put("event.name", new RegisteredEventListener<>("event.name", message -> Mono.empty(), String.class));
+        eventsToBind.put("event.name2", new RegisteredEventListener<>("event.name2", message -> Mono.empty(), String.class));
+        Map<String, RegisteredEventListener<?>> notificationEventListeners = new ConcurrentHashMap<>();
+        Map<String, RegisteredQueryHandler<?, ?>> queryHandlers = new ConcurrentHashMap<>();
+        resolver = new HandlerResolver(queryHandlers, eventListeners, eventsToBind, notificationEventListeners, commandHandlers);
+    }
+
+    @Test
+    void shouldGetOnlyTheBindingEvents() {
+        // Act
+        Collection<RegisteredEventListener<?>> eventListener = resolver.getEventListeners();
+        // Assert
+        Assertions.assertThat(eventListener.size()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldMatchForAWildcardEvent() {
+        // Act
+        RegisteredEventListener<Object> eventListener = resolver.getEventListener("some.sample");
+        // Assert
+        Assertions.assertThat(eventListener.getPath()).isEqualTo("some.*");
+    }
+
+    @Test
+    void shouldMatchForAnExactEvent() {
+        // Act
+        RegisteredEventListener<Object> eventListener = resolver.getEventListener("event.name");
+        // Assert
+        Assertions.assertThat(eventListener.getPath()).isEqualTo("event.name");
+    }
+
+}

--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/listeners/ApplicationCommandListenerPerfTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/listeners/ApplicationCommandListenerPerfTest.java
@@ -271,7 +271,7 @@ class ApplicationCommandListenerPerfTest {
         final HandlerRegistry registry = range(0, 20).reduce(initialRegistry, (r, i) -> r.handleCommand("app.command.name" + i, message -> Mono.empty(), Map.class)).block();
         final ConcurrentMap<String, RegisteredCommandHandler<?>> commandHandlers = registry.getCommandHandlers().stream()
                 .collect(ConcurrentHashMap::new, (map, handler) -> map.put(handler.getPath(), handler), ConcurrentHashMap::putAll);
-        return new HandlerResolver(null, null, null, commandHandlers) {
+        return new HandlerResolver(null, null, null, null, commandHandlers) {
             @Override
             @SuppressWarnings("unchecked")
             public RegisteredCommandHandler<Object> getCommandHandler(String path) {

--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/listeners/ApplicationQueryListenerTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/listeners/ApplicationQueryListenerTest.java
@@ -80,7 +80,7 @@ class ApplicationQueryListenerTest {
         QueryHandler<String, SampleClass> handler = (message) -> just("OK");
         handlers.put("queryDirect", new RegisteredQueryHandler<>("queryDirect",
                 (from, message) -> handler.handle(message), SampleClass.class));
-        HandlerResolver resolver = new HandlerResolver(handlers, null, null, null);
+        HandlerResolver resolver = new HandlerResolver(handlers, null,null, null, null);
         applicationQueryListener = new ApplicationQueryListener(reactiveMessageListener, "queue", resolver, sender,
                 "directExchange", messageConverter, "replyExchange", false,
                 1, 100, maxLengthBytes, true, discardNotifier, errorReporter);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.3
+version=1.0.4
 springBootVersion=2.4.2
 gradleVersionsVersion=0.36.0
 toPublish=async-commons,async-commons-api,async-commons-rabbit-standalone,async-commons-rabbit-starter,domain-events-api,async-rabbit

--- a/samples/async/receiver-responder/src/main/java/sample/SampleReceiverApp.java
+++ b/samples/async/receiver-responder/src/main/java/sample/SampleReceiverApp.java
@@ -8,6 +8,7 @@ import org.reactivecommons.api.domain.DomainEvent;
 import org.reactivecommons.api.domain.DomainEventBus;
 import org.reactivecommons.async.api.DirectAsyncGateway;
 import org.reactivecommons.async.api.HandlerRegistry;
+import org.reactivecommons.async.api.handlers.EventHandler;
 import org.reactivecommons.async.api.handlers.QueryHandler;
 import org.reactivecommons.async.impl.config.annotations.EnableDirectAsyncGateway;
 import org.reactivecommons.async.impl.config.annotations.EnableDomainEventBus;
@@ -49,6 +50,8 @@ public class SampleReceiverApp {
     @Bean
     public HandlerRegistry handlerRegistrySubs(DirectAsyncGateway gateway) {
         return HandlerRegistry.register()
+                .handleDynamicEvents("dynamic.*", message -> Mono.empty(), Object.class)
+                .listenEvent("fixed.event", message -> Mono.empty(), Object.class)
                 .serveQuery("query1", message -> {
                     log.info("resolving from direct query");
                     return just(new RespQuery1("Ok", message));


### PR DESCRIPTION
remove dynamic bindings like "sample.*" you should explicitly use `handleDynamicEvents` from the `HandlerRegistry` and the `startListeningEvent` from the `DynamicRegistry` instance.