### PR TITLE
73: Updated tests for NameGenerator

### DIFF
--- a/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
@@ -1,0 +1,25 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NameGeneratorTest {
+
+    private NameGenerator nameGenerator;
+
+    @Test
+    void generateNameFromWithoutSuffix() {
+        String result = NameGenerator.generateNameFrom("application");
+        assertFalse(result.contains("="));
+        assertTrue(result.startsWith("application--"));
+        assertEquals(35, result.length());
+    }
+
+    @Test
+    void generateNameFromWithSuffix() {
+        String result = NameGenerator.generateNameFrom("application", "suffix");
+        assertFalse(result.contains("="));
+        assertTrue(result.startsWith("application-suffix-"));
+        assertEquals(41, result.length());
+    }
+}

--- a/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class NameGeneratorTest {
 
-    private NameGenerator nameGenerator;
-
     @Test
     void generateNameFromWithoutSuffix() {
         String result = NameGenerator.generateNameFrom("application");

--- a/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
+++ b/async/async-commons/src/test/java/org/reactivecommons/async/commons/utils/NameGeneratorTest.java
@@ -1,4 +1,5 @@
-import org.junit.jupiter.api.BeforeEach;
+package org.reactivecommons.async.commons.utils;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
Close: #73 

Added unit tests for NameGenerator class. 
Not directly testing the generated value as it used random UUID. 

Could have used powermock to mock results but that is more relevant to legacy code that has challenges in being tested. 
Believe the assertions within this test address the intended results. 