### PR TITLE
fix(health): Use blocking IO for health indicator connection

### DIFF
--- a/async/async-rabbit-starter-eda/src/test/java/org/reactivecommons/async/rabbit/health/DomainRabbitReactiveHealthIndicatorTest.java
+++ b/async/async-rabbit-starter-eda/src/test/java/org/reactivecommons/async/rabbit/health/DomainRabbitReactiveHealthIndicatorTest.java
@@ -37,12 +37,14 @@ public class DomainRabbitReactiveHealthIndicatorTest {
 
     @BeforeEach
     void setup() {
+        when(provider.getConnectionFactory()).thenReturn(factory);
+        when(factory.clone()).thenReturn(factory);
+
         ConnectionManager connectionManager = new ConnectionManager();
         connectionManager.addDomain(DEFAULT_DOMAIN, null, null, provider);
         connectionManager.addDomain("domain2", null, null, provider);
         connectionManager.addDomain("domain3", null, null, provider);
         indicator = new DomainRabbitReactiveHealthIndicator(connectionManager);
-        when(provider.getConnectionFactory()).thenReturn(factory);
     }
 
     @Test


### PR DESCRIPTION
The health indicator connections now use blocking IO to avoid errors when closing socket connections when the TLS connection is enabled 