### PR TITLE
feat: Ensure Single RabbitMQ Connection and Validate Properties

### DIFF
--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/communications/UnroutableMessageNotifierTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/communications/UnroutableMessageNotifierTest.java
@@ -44,9 +44,9 @@ class UnroutableMessageNotifierTest {
 
     @BeforeEach
     void setUp() {
-        // Usar el constructor por defecto y espiar el sink interno
+        // Use the default constructor and spy on the internal sink
         unroutableMessageNotifier = new UnroutableMessageNotifier();
-        // Inyectar el mock del sink usando un spy para poder verificarlo
+        // Inject the sink mock using a spy to verify it
         try {
             java.lang.reflect.Field sinkField = UnroutableMessageNotifier.class.getDeclaredField("sink");
             sinkField.setAccessible(true);

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'org.sonarqube' version '6.3.1.5724'
     id 'org.springframework.boot' version '3.5.5' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'co.com.bancolombia.cleanArchitecture' version '3.25.0'
+    id 'co.com.bancolombia.cleanArchitecture' version '3.26.1'
 }
 
 repositories {

--- a/main.gradle
+++ b/main.gradle
@@ -22,7 +22,7 @@ allprojects {
                 property 'sonar.organization', 'reactive-commons'
                 property 'sonar.host.url', 'https://sonarcloud.io'
                 property "sonar.sources", "src/main"
-                property "sonar.test", "src/test"
+                property "sonar.tests", "src/test"
                 property "sonar.java.binaries", "build/classes"
                 property "sonar.junit.reportPaths", "build/test-results/test"
                 property "sonar.java-coveragePlugin", "jacoco"
@@ -86,7 +86,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.4'
+            mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.5'
         }
     }
 

--- a/starters/async-commons-starter/src/main/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomain.java
+++ b/starters/async-commons-starter/src/main/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomain.java
@@ -32,11 +32,11 @@ public class GenericAsyncPropsDomain<T extends GenericAsyncProps<P>, P> extends 
         this.asyncPropsClass = asyncPropsClass;
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
-        this.computeIfAbsent(DEFAULT_DOMAIN, k -> {
-            T defaultApp = AsyncPropsDomainBuilder.instantiate(asyncPropsClass);
-            defaultApp.setConnectionProperties(mapper.convertValue(defaultProperties, propsClass));
-            return defaultApp;
-        });
+
+        if (!this.containsKey(DEFAULT_DOMAIN)) {
+            throw new InvalidConfigurationException("Required domain '" + DEFAULT_DOMAIN + "' is not configured.");
+        }
+
         super.forEach((key, value) -> { // To ensure that each domain has an appName
             if (value.getAppName() == null) {
                 if (defaultAppName == null || defaultAppName.isEmpty()) {

--- a/starters/async-commons-starter/src/test/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomainTest.java
+++ b/starters/async-commons-starter/src/test/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomainTest.java
@@ -25,6 +25,8 @@ class GenericAsyncPropsDomainTest {
         String defaultAppName = "sample";
         MyBrokerConnProps defaultMyBrokerProps = new MyBrokerConnProps();
         AsyncMyBrokerPropsDomainProperties configured = new AsyncMyBrokerPropsDomainProperties();
+        configured.put(DEFAULT_DOMAIN, new MyBrokerAsyncProps());
+
         MyBrokerAsyncProps other = new MyBrokerAsyncProps();
         other.setAppName(OTHER);
         configured.put(OTHER, other);

--- a/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProvider.java
+++ b/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProvider.java
@@ -141,7 +141,7 @@ public record RabbitMQBrokerProvider(String domain,
 
     @Override
     public void listenReplies() {
-        if (props.isListenReplies()) {
+        if (Boolean.TRUE.equals(props.getListenReplies())) {
             final ApplicationReplyListener replyListener = new ApplicationReplyListener(router,
                     receiver,
                     props.getBrokerConfigProps().getReplyQueue(),

--- a/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/props/AsyncProps.java
+++ b/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/props/AsyncProps.java
@@ -54,7 +54,14 @@ public class AsyncProps extends GenericAsyncProps<RabbitProperties> {
     private Integer retryDelay = 1000;
 
     @Builder.Default
-    private boolean listenReplies = true;
+    private Boolean listenReplies = null;
+
+    public Boolean getListenReplies() {
+        if (listenReplies == null) {
+            throw new IllegalArgumentException("The 'listenReplies' property is required, please specify a 'true' or 'false' value.");
+        }
+        return listenReplies;
+    }
 
     @Builder.Default
     private Boolean withDLQRetry = false;

--- a/starters/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProviderTest.java
+++ b/starters/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProviderTest.java
@@ -80,6 +80,7 @@ class RabbitMQBrokerProviderTest {
         IBrokerConfigProps configProps = new BrokerConfigProps(props);
         props.setBrokerConfigProps(configProps);
         props.setAppName("test");
+        props.setListenReplies(Boolean.TRUE);
         brokerProvider = new RabbitMQBrokerProvider(DEFAULT_DOMAIN,
                 props,
                 brokerConfig,

--- a/starters/async-rabbit-starter/src/test/resources/application.properties
+++ b/starters/async-rabbit-starter/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=test-app

--- a/starters/async-rabbit-starter/src/test/resources/application.yaml
+++ b/starters/async-rabbit-starter/src/test/resources/application.yaml
@@ -1,0 +1,10 @@
+# Default App Name
+spring:
+  application:
+    name: test-app
+
+# Async Props
+app:
+  async:
+    app: # this is the name of the default domain
+      listenReplies: true


### PR DESCRIPTION
This PR introduces key improvements to the system's robustness and efficiency:
1. Ensures that a single physical connection to RabbitMQ is created and reused throughout the application.
2. Adds validations to make the listenReplies configuration property and the app domain mandatory, preventing ambiguous behavior and runtime errors.