### PR TITLE
feat: Only one connection to the RabbitMQ broker is used

### DIFF
--- a/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/communications/UnroutableMessageNotifierTest.java
+++ b/async/async-rabbit/src/test/java/org/reactivecommons/async/rabbit/communications/UnroutableMessageNotifierTest.java
@@ -44,9 +44,9 @@ class UnroutableMessageNotifierTest {
 
     @BeforeEach
     void setUp() {
-        // Usar el constructor por defecto y espiar el sink interno
+        // Use the default constructor and spy on the internal sink
         unroutableMessageNotifier = new UnroutableMessageNotifier();
-        // Inyectar el mock del sink usando un spy para poder verificarlo
+        // Inject the sink mock using a spy to verify it
         try {
             java.lang.reflect.Field sinkField = UnroutableMessageNotifier.class.getDeclaredField("sink");
             sinkField.setAccessible(true);

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'org.sonarqube' version '6.3.1.5724'
     id 'org.springframework.boot' version '3.5.5' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'co.com.bancolombia.cleanArchitecture' version '3.25.0'
+    id 'co.com.bancolombia.cleanArchitecture' version '3.26.1'
 }
 
 repositories {

--- a/docs/docs/migration-guides.md
+++ b/docs/docs/migration-guides.md
@@ -1,0 +1,214 @@
+---
+sidebar_position: 4
+---
+
+# Migration
+
+## From 5.x.x to 6.x.x
+
+### Change notes
+
+- The configuration property `listenReplies` for RabbitMQ now defaults to `null`. Previously, it was `true`, causing all
+  applications to subscribe to a reply queue even when not needed.
+- The domain `app` is now **required**. If not defined, the application will fail to start.
+
+### Actions
+
+- If your application uses the ReqReply pattern, you must explicitly set `app.async.app.listenReplies` to `true`.
+  Otherwise, it should be `false` to avoid unnecessary resource usage:
+
+```yaml title="application.yaml"
+app:
+  async:
+    app:
+      listenReplies: true # set to true if ReqReply is required, false if not
+```
+
+```java title="Programmatic configuration"
+
+@Configuration
+public class MyDomainConfig {
+
+    @Bean
+    @Primary
+    public AsyncRabbitPropsDomainProperties customDomainProperties() {
+        RabbitProperties propertiesApp = new RabbitProperties();
+        // Additional connection configuration goes here...
+        return AsyncRabbitPropsDomainProperties.builder()
+                .withDomain("app", AsyncProps.builder()
+                        .connectionProperties(propertiesApp)
+                        .listenReplies(Boolean.TRUE) // set to true if ReqReply is required, false if not
+                        .build())
+                .build();
+    }
+}
+```
+
+---
+
+- The domain `app` must be defined in your configuration. Otherwise, the application will throw an exception at startup:
+
+```yaml title="application.yaml"
+app:
+  async:
+    app: # Configure the 'app' domain
+    # domain configuration goes here
+```
+
+```java title="Programmatic configuration"
+
+@Configuration
+public class MyDomainConfig {
+
+    @Bean
+    @Primary
+    public AsyncRabbitPropsDomainProperties customDomainProperties() {
+        RabbitProperties propertiesApp = new RabbitProperties();
+        // Additional connection configuration goes here...
+        return AsyncRabbitPropsDomainProperties.builder()
+                .withDomain("app", AsyncProps.builder() // Configure the 'app' domain
+                        .connectionProperties(propertiesApp)
+                        .build())
+                .build();
+    }
+}
+```
+
+## From 4.x.x to 5.x.x
+
+### New Features
+
+- Support for multiple brokers: It is now possible to configure and connect to up to two brokers simultaneously, using
+  independent domains in the configuration.
+
+### Change notes
+
+- Configuration properties are now defined per domain, allowing each to have its own properties and connection
+  settings.
+- The broker connection is no longer manually defined in the code. It is now automatically managed based on the
+  configuration declared in the `application.yaml` file or through programmatic configuration.
+
+### Actions
+
+- The `app` domain needs to be defined to specify the configuration properties.
+
+Before:
+
+```yaml title="application.yaml"
+app:
+  async:
+    withDLQRetry: true
+    maxRetries: 1
+    retryDelay: 1000
+```
+
+Now:
+
+```yaml title="application.yaml"
+app:
+  async:
+    app: # this is the name of the default domain
+      withDLQRetry: true
+      maxRetries: 1
+      retryDelay: 1000
+```
+
+- Migrate the connection configuration:
+
+Before: the connection was defined manually in a Java class, as shown below:
+
+```java
+
+@Log4j2
+@Configuration
+@RequiredArgsConstructor
+public class MyDomainConfig {
+
+    private final RabbitMQConnectionProperties properties;
+    private static final String TLS = "TLSv1.2";
+    private static final String FAIL_MSG = "Error creating ConnectionFactoryProvider in enroll";
+
+    @Primary
+    @Bean
+    public ConnectionFactoryProvider getConnectionFactoryProvider() {
+        final var factory = new ConnectionFactory();
+        var map = PropertyMapper.get();
+        map.from(properties::hostname).whenNonNull().to(factory::setHost);
+        map.from(properties::port).to(factory::setPort);
+        map.from(properties::username).whenNonNull().to(factory::setUsername);
+        map.from(properties::password).whenNonNull().to(factory::setPassword);
+        map.from(properties::ssl).whenTrue().as(isSsl -> factory).to(this::configureSsl);
+        return () -> factory;
+    }
+
+    private void configureSsl(ConnectionFactory factory) {
+        try {
+            var sslContext = SSLContext.getInstance(TLS);
+            var trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+            factory.useSslProtocol(sslContext);
+        } catch (KeyManagementException | KeyStoreException | NoSuchAlgorithmException e) {
+            log.error("{}: {}", FAIL_MSG, e);
+        }
+    }
+}
+```
+
+Now: the connection is configured directly in the `application.yaml` file per domain:
+
+```yaml title="application.yaml"
+app:
+  async:
+    app: # this is the name of the default domain
+      connectionProperties: # you can override the connection properties of each domain
+        host: localhost
+        port: 5672
+        username: guest
+        password: guest
+        virtual-host: /
+    # Another domain can be configured with same properties structure that app
+    accounts: # this is a second domain name and can have another independent setup
+      connectionProperties: # you can override the connection properties of each domain
+        host: localhost
+        port: 5672
+        username: guest
+        password: guest
+        virtual-host: /accounts
+```
+
+Domains can also be configured programmatically:
+
+```java title="Programmatic configuration"
+
+@Configuration
+public class MyDomainConfig {
+
+    @Bean
+    @Primary
+    public AsyncRabbitPropsDomainProperties customDomainProperties() {
+        RabbitProperties propertiesApp = new RabbitProperties();
+        propertiesApp.setHost("localhost");
+        propertiesApp.setPort(5672);
+        propertiesApp.setVirtualHost("/");
+        propertiesApp.setUsername("guest");
+        propertiesApp.setPassword("guest");
+
+        RabbitProperties propertiesAccounts = new RabbitProperties();
+        propertiesAccounts.setHost("localhost");
+        propertiesAccounts.setPort(5672);
+        propertiesAccounts.setVirtualHost("/accounts");
+        propertiesAccounts.setUsername("guest");
+        propertiesAccounts.setPassword("guest");
+
+        return AsyncRabbitPropsDomainProperties.builder()
+                .withDomain("app", AsyncProps.builder()
+                        .connectionProperties(propertiesApp)
+                        .build())
+                .withDomain("accounts", AsyncProps.builder()
+                        .connectionProperties(propertiesAccounts)
+                        .build())
+                .build();
+    }
+}
+```

--- a/docs/docs/reactive-commons/1-getting-started.md
+++ b/docs/docs/reactive-commons/1-getting-started.md
@@ -17,7 +17,7 @@ Commons.
 
 You need Java JRE installed (Java 17 or later).
 
-You also need to install RabbitMQ. Follow the [instructions from the website](https://www.rabbitmq.com/download.html)
+You also need to install RabbitMQ. Follow the [instructions from the website](https://www.rabbitmq.com/download.html).
 
 ## Start RabbitMQ
 
@@ -50,7 +50,8 @@ dependencies {
 }
 ```
 
-Note: If you will use Cloud Events, you should include the Cloud Events dependency:
+:::tip
+If you will use Cloud Events, you should include the Cloud Events dependency:
 
 ```groovy
 dependencies {
@@ -58,7 +59,7 @@ dependencies {
 }
 ```
 
-```groovy
+:::
 
 ### Configuration properties
 

--- a/docs/docs/reactive-commons/3-sending-a-command.md
+++ b/docs/docs/reactive-commons/3-sending-a-command.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Sending a Command

--- a/docs/docs/reactive-commons/_category_.json
+++ b/docs/docs/reactive-commons/_category_.json
@@ -1,6 +1,7 @@
 {
   "label": "Reactive Commons",
   "position": 2,
+  "collapsed": false,
   "link": {
     "type": "generated-index",
     "description": "Learn how to build reactive systems using the Reactive Commons library."

--- a/docs/docs/reactive-commons/configuration_properties/2-kafka.md
+++ b/docs/docs/reactive-commons/configuration_properties/2-kafka.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 2
+---
+
+# Kafka Configuration
+
+You can customize some predefined variables of Reactive Commons.
+
+This can be done by Spring Boot `application.yaml` or by overriding
+the [AsyncKafkaProps](https://github.com/reactive-commons/reactive-commons-java/blob/master/starters/async-kafka-starter/src/main/java/org/reactivecommons/async/kafka/config/props/AsyncKafkaProps.java)
+bean.
+
+```yaml
+reactive:
+  commons:
+    kafka:
+      app: # this is the name of the default domain
+        withDLQRetry: false # if you want to have dlq queues with retries you can set it to true, you cannot change it after queues are created, because you will get an error, so you should delete topology before the change.
+        maxRetries: -1 # -1 will be considered default value. When withDLQRetry is true, it will be retried 10 times. When withDLQRetry is false, it will be retried indefinitely.
+        retryDelay: 1000 # interval for message retries, with and without DLQRetry
+        checkExistingTopics: true # if you don't want to verify topic existence before send a record you can set it to false
+        createTopology: true # if your organization have restrictions with automatic topology creation you can set it to false and create it manually or by your organization process.
+        useDiscardNotifierPerDomain: false # if true it uses a discard notifier for each domain,when false it uses a single discard notifier for all domains with default 'app' domain
+        enabled: true # if you want to disable this domain you can set it to false
+        brokerType: "kafka" # please don't change this value
+        domain:
+          ignoreThisListener: false # Allows you to disable event listener for this specific domain
+        connectionProperties: # you can override the connection properties of each domain
+          bootstrap-servers: localhost:9092
+      # Another domain can be configured with same properties structure that app
+      accounts: # this is a second domain name and can have another independent setup
+        connectionProperties: # you can override the connection properties of each domain
+          bootstrap-servers: localhost:9093
+```
+
+You can override this settings programmatically through a `AsyncKafkaPropsDomainProperties` bean:
+
+```java
+package sample;
+
+import org.reactivecommons.async.kafka.config.KafkaProperties;
+import org.reactivecommons.async.kafka.config.props.AsyncProps;
+import org.reactivecommons.async.kafka.config.props.AsyncKafkaPropsDomainProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class MyDomainConfig {
+
+    @Bean
+    @Primary
+    public AsyncKafkaPropsDomainProperties customKafkaDomainProperties() {
+        KafkaProperties propertiesApp = new KafkaProperties();
+        propertiesApp.setBootstrapServers(List.of("localhost:9092"));
+
+        KafkaProperties propertiesAccounts = new KafkaProperties();
+        propertiesAccounts.setBootstrapServers(List.of("localhost:9093"));
+
+        return AsyncKafkaPropsDomainProperties.builder()
+                .withDomain("app", AsyncProps.builder()
+                        .connectionProperties(propertiesApp)
+                        .build())
+                .withDomain("accounts", AsyncProps.builder()
+                        .connectionProperties(propertiesAccounts)
+                        .build())
+                .build();
+    }
+}
+```
+
+## Loading properties from a secret
+
+Additionally, if you want to set only connection properties you can use the `AsyncKafkaPropsDomain.KafkaSecretFiller`
+class.
+
+```java
+
+@Bean
+@Primary
+public AsyncKafkaPropsDomain.KafkaSecretFiller customKafkaFiller() {
+    return (domain, asyncProps) -> {
+        // customize asyncProps here by domain
+    };
+}
+```

--- a/docs/docs/reactive-commons/configuration_properties/_category_.json
+++ b/docs/docs/reactive-commons/configuration_properties/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Configuration Properties",
+  "position": 9
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,11 +17,11 @@
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-common": "^3.8.1",
-    "@mdx-js/react": "^3.1.0",
+    "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.8.1",

--- a/main.gradle
+++ b/main.gradle
@@ -22,7 +22,7 @@ allprojects {
                 property 'sonar.organization', 'reactive-commons'
                 property 'sonar.host.url', 'https://sonarcloud.io'
                 property "sonar.sources", "src/main"
-                property "sonar.test", "src/test"
+                property "sonar.tests", "src/test"
                 property "sonar.java.binaries", "build/classes"
                 property "sonar.junit.reportPaths", "build/test-results/test"
                 property "sonar.java-coveragePlugin", "jacoco"
@@ -86,7 +86,7 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.4'
+            mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.5'
         }
     }
 

--- a/starters/async-commons-starter/src/main/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomain.java
+++ b/starters/async-commons-starter/src/main/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomain.java
@@ -32,11 +32,11 @@ public class GenericAsyncPropsDomain<T extends GenericAsyncProps<P>, P> extends 
         this.asyncPropsClass = asyncPropsClass;
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
-        this.computeIfAbsent(DEFAULT_DOMAIN, k -> {
-            T defaultApp = AsyncPropsDomainBuilder.instantiate(asyncPropsClass);
-            defaultApp.setConnectionProperties(mapper.convertValue(defaultProperties, propsClass));
-            return defaultApp;
-        });
+
+        if (!this.containsKey(DEFAULT_DOMAIN)) {
+            throw new InvalidConfigurationException("Required domain '" + DEFAULT_DOMAIN + "' is not configured.");
+        }
+
         super.forEach((key, value) -> { // To ensure that each domain has an appName
             if (value.getAppName() == null) {
                 if (defaultAppName == null || defaultAppName.isEmpty()) {

--- a/starters/async-commons-starter/src/test/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomainTest.java
+++ b/starters/async-commons-starter/src/test/java/org/reactivecommons/async/starter/props/GenericAsyncPropsDomainTest.java
@@ -25,6 +25,8 @@ class GenericAsyncPropsDomainTest {
         String defaultAppName = "sample";
         MyBrokerConnProps defaultMyBrokerProps = new MyBrokerConnProps();
         AsyncMyBrokerPropsDomainProperties configured = new AsyncMyBrokerPropsDomainProperties();
+        configured.put(DEFAULT_DOMAIN, new MyBrokerAsyncProps());
+
         MyBrokerAsyncProps other = new MyBrokerAsyncProps();
         other.setAppName(OTHER);
         configured.put(OTHER, other);

--- a/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProvider.java
+++ b/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProvider.java
@@ -141,7 +141,7 @@ public record RabbitMQBrokerProvider(String domain,
 
     @Override
     public void listenReplies() {
-        if (props.isListenReplies()) {
+        if (Boolean.TRUE.equals(props.getListenReplies())) {
             final ApplicationReplyListener replyListener = new ApplicationReplyListener(router,
                     receiver,
                     props.getBrokerConfigProps().getReplyQueue(),

--- a/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/props/AsyncProps.java
+++ b/starters/async-rabbit-starter/src/main/java/org/reactivecommons/async/rabbit/config/props/AsyncProps.java
@@ -54,7 +54,14 @@ public class AsyncProps extends GenericAsyncProps<RabbitProperties> {
     private Integer retryDelay = 1000;
 
     @Builder.Default
-    private boolean listenReplies = true;
+    private Boolean listenReplies = null;
+
+    public Boolean getListenReplies() {
+        if (listenReplies == null) {
+            throw new IllegalArgumentException("The 'listenReplies' property is required, please specify a 'true' or 'false' value.");
+        }
+        return listenReplies;
+    }
 
     @Builder.Default
     private Boolean withDLQRetry = false;

--- a/starters/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProviderTest.java
+++ b/starters/async-rabbit-starter/src/test/java/org/reactivecommons/async/rabbit/RabbitMQBrokerProviderTest.java
@@ -80,6 +80,7 @@ class RabbitMQBrokerProviderTest {
         IBrokerConfigProps configProps = new BrokerConfigProps(props);
         props.setBrokerConfigProps(configProps);
         props.setAppName("test");
+        props.setListenReplies(Boolean.TRUE);
         brokerProvider = new RabbitMQBrokerProvider(DEFAULT_DOMAIN,
                 props,
                 brokerConfig,

--- a/starters/async-rabbit-starter/src/test/resources/application.properties
+++ b/starters/async-rabbit-starter/src/test/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=test-app

--- a/starters/async-rabbit-starter/src/test/resources/application.yaml
+++ b/starters/async-rabbit-starter/src/test/resources/application.yaml
@@ -1,0 +1,10 @@
+# Default App Name
+spring:
+  application:
+    name: test-app
+
+# Async Props
+app:
+  async:
+    app: # this is the name of the default domain
+      listenReplies: true


### PR DESCRIPTION
# Features
- Only one connection to the RabbitMQ broker is used for both sending and listening to messages.
- Add migration documentation for projects using RabbitMQ, detailing the changes introduced in version 6.x.x